### PR TITLE
Return information about extracted constants from `pg_query_normalize`

### DIFF
--- a/pg_query.h
+++ b/pg_query.h
@@ -66,8 +66,19 @@ typedef struct {
 } PgQueryFingerprintResult;
 
 typedef struct {
+  int location;   /* start offset in query text */
+  int length;     /* length in bytes, or -1 to ignore */
+  int param_id;   /* Param id to use - if negative prefix, need to abs(..) and add highest_extern_param_id */
+  int token;      /* constant token type as reported by lexer */
+  char *val;      /* constant value */
+} PgQueryNormalizeConstLocation;
+
+typedef struct {
   char* normalized_query;
   PgQueryError* error;
+  PgQueryNormalizeConstLocation *clocations;
+  int clocations_count;
+  int highest_extern_param_id;
 } PgQueryNormalizeResult;
 
 // Postgres parser options (parse mode and GUCs that affect parsing)

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -48,6 +48,8 @@ const char* tests[] = {
   "CLOSE cursor_a",
   "SELECT 1; ALTER USER a WITH PASSWORD 'b'",
   "SELECT $1; ALTER USER a WITH PASSWORD $2",
+  "SELECT U&'d!0061t!+000061' UESCAPE '!'",
+  "SELECT $1",
 };
 
 size_t testsLength = __LINE__ - 7;

--- a/test/normalize_tests.c
+++ b/test/normalize_tests.c
@@ -48,8 +48,8 @@ const char* tests[] = {
   "CLOSE cursor_a",
   "SELECT 1; ALTER USER a WITH PASSWORD 'b'",
   "SELECT $1; ALTER USER a WITH PASSWORD $2",
-  "SELECT U&'d!0061t!+000061' UESCAPE '!'",
-  "SELECT $1",
+  "SELECT U&'d!0061t!+000061' UESCAPE '!', -2147483647, -2147483648, x'beef', b'010101'",
+  "SELECT $1, $2, $3, $4, $5",
 };
 
 size_t testsLength = __LINE__ - 7;


### PR DESCRIPTION
`PgQueryNormalizeResult` now includes information about the extracted
constants, their location and extent, as well as the lexer token type
and the value of constants as interpreted by the lexer.  This makes
`pg_query_normalize` usable not just for query identification, but also
as a basis for automatic conversion of literal queries into
constant-agnostic prepared statements or other applications where
auto-parametrization of queries is useful.

This also makes `pg_query_normalize` to use `base_yylex` instead of
`core_yylex` which normalizes `USCONST` constants properly.
